### PR TITLE
Fix: Rename references and namespaces after move to ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/php-library-template
+ * @see https://github.com/ergebnis/php-library-template
  */
 
 use Localheinz\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2019 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/php-library-template
+@see https://github.com/ergebnis/php-library-template
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ For a full diff see [`1902cc2...master`][1902cc2...master].
 
 *
 
-[1902cc2...master]: https://github.com/localheinz/php-library-template/compare/1902cc2...master
+[1902cc2...master]: https://github.com/ergebnis/php-library-template/compare/1902cc2...master
 
-[#9000]: https://github.com/localheinz/php-library-template/pull/9000
+[#9000]: https://github.com/ergebnis/php-library-template/pull/9000
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # php-library-template
 
-[![Continuous Integration](https://github.com/localheinz/php-library-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/php-library-template/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/php-library-template/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/php-library-template)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/php-library-template/v/stable)](https://packagist.org/packages/localheinz/php-library-template)
-[![Total Downloads](https://poser.pugx.org/localheinz/php-library-template/downloads)](https://packagist.org/packages/localheinz/php-library-template)
+[![Continuous Integration](https://github.com/ergebnis/php-library-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/php-library-template/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-library-template)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/php-library-template/v/stable)](https://packagist.org/packages/ergebnis/php-library-template)
+[![Total Downloads](https://poser.pugx.org/ergebnis/php-library-template/downloads)](https://packagist.org/packages/ergebnis/php-library-template)
 
 ## Installation
 
@@ -12,7 +12,7 @@
 Run
 
 ```
-$ composer require localheinz/php-library-template
+$ composer require ergebnis/php-library-template
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "localheinz/php-library-template",
+  "name": "ergebnis/php-library-template",
   "type": "library",
   "description": "Provides a GitHub repository template for a PHP library, using GitHub actions.",
-  "homepage": "https://github.com/localheinz/php-library-template",
+  "homepage": "https://github.com/ergebnis/php-library-template",
   "license": "MIT",
   "authors": [
     {
@@ -31,16 +31,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Library\\": "src/"
+      "Ergebnis\\Library\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Library\\Test\\": "test/"
+      "Ergebnis\\Library\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/php-library-template/issues",
-    "source": "https://github.com/localheinz/php-library-template"
+    "issues": "https://github.com/ergebnis/php-library-template/issues",
+    "source": "https://github.com/ergebnis/php-library-template"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f7c3a23060cdc596b37e03f779cd284",
+    "content-hash": "c1bdc942ee8b8a9bcaad2ba8f99498f6",
     "packages": [],
     "packages-dev": [
         {
@@ -1935,18 +1935,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "role": "Developer",
-                    "email": "sebastian@phpeople.de"
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "Developer",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
@@ -2588,8 +2588,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -2630,8 +2630,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -2679,8 +2679,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -3532,8 +3532,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -3575,8 +3575,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -4609,8 +4609,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/src/Example.php
+++ b/src/Example.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/php-library-template
+ * @see https://github.com/ergebnis/php-library-template
  */
 
-namespace Localheinz\Library;
+namespace Ergebnis\Library;
 
 final class Example
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/php-library-template
+ * @see https://github.com/ergebnis/php-library-template
  */
 
-namespace Localheinz\Library\Test\AutoReview;
+namespace Ergebnis\Library\Test\AutoReview;
 
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Library\\',
-            'Localheinz\\Library\\Test\\Unit\\'
+            'Ergebnis\\Library\\',
+            'Ergebnis\\Library\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/php-library-template
+ * @see https://github.com/ergebnis/php-library-template
  */
 
-namespace Localheinz\Library\Test\Unit;
+namespace Ergebnis\Library\Test\Unit;
 
-use Localheinz\Library\Example;
+use Ergebnis\Library\Example;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Library\Example
+ * @covers \Ergebnis\Library\Example
  */
 final class ExampleTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames references and namespaces after move to @ergebnis