### PR TITLE
Fix: Use released versions of shivammathur/setup-php

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: none
           extension-csv: "mbstring"
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: none
           extension-csv: "mbstring"
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: none
           extension-csv: "mbstring"
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: none
           extension-csv: "mbstring"
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: xdebug
           extension-csv: "mbstring"
@@ -248,7 +248,7 @@ jobs:
         uses: actions/checkout@v1.1.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           coverage: xdebug
           extension-csv: "mbstring"


### PR DESCRIPTION
This PR

* [x] uses released versions of `shivammathur/setup-php` instead of using `master`
