### PR TITLE
Fix: Do not include bleedingEdge.neon anymore

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 includes:
 	- phpstan-baseline.neon
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 
 parameters:
 	classesAllowedToBeExtended:


### PR DESCRIPTION
This PR

* [x] stops including `bleedingEdge.neon`