### PR TITLE
Fix: Remove non-applicable configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,10 +2,6 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	classesAllowedToBeExtended:
-		- InvalidArgumentException
-		- RuntimeException
-		- Symfony\Component\Console\Command\Command
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:


### PR DESCRIPTION
This PR

* [x] removes non-applicable configuration from `phpstan.neon`