### PR TITLE
Enhancement: Use ergebnis/phpstan-rules instead of localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
+    "ergebnis/phpstan-rules": "~0.14.0",
     "ergebnis/test-util": "~0.9.0",
     "infection/infection": "~0.15.0",
     "jangregor/phpstan-prophecy": "~0.4.2",
     "localheinz/composer-normalize": "^1.3.1",
-    "localheinz/phpstan-rules": "~0.13.0",
     "phpstan/extension-installer": "^1.0.3",
     "phpstan/phpstan": "~0.11.19",
     "phpstan/phpstan-deprecation-rules": "~0.11.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70234e3ade779676faa49767321bf6e7",
+    "content-hash": "26816f24bc04241ef6af3bfd9545a23c",
     "packages": [],
     "packages-dev": [
         {
@@ -401,6 +401,73 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/ergebnis/php-cs-fixer-config",
             "time": "2019-11-25T19:01:52+00:00"
+        },
+        {
+            "name": "ergebnis/phpstan-rules",
+            "version": "0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/phpstan-rules.git",
+                "reference": "217772cd009ec8a10f44c827137c4c4c85126258"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/phpstan-rules/zipball/217772cd009ec8a10f44c827137c4c4c85126258",
+                "reference": "217772cd009ec8a10f44c827137c4c4c85126258",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "nikic/php-parser": "^4.2.3",
+                "php": "^7.2",
+                "phpstan/phpstan": "~0.11.15 || ~0.12.0"
+            },
+            "replace": {
+                "localheinz/phpstan-rules": "*"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "ergebnis/test-util": "~0.9.0",
+                "infection/infection": "~0.13.6",
+                "localheinz/composer-normalize": "^1.3.1",
+                "nette/di": "^3.0.1",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.5.0",
+                "psr/container": "^1.0.0",
+                "zendframework/zend-servicemanager": "^2.0.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/ergebnis/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2019-12-09T22:36:56+00:00"
         },
         {
             "name": "ergebnis/test-util",
@@ -1130,69 +1197,8 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
-        },
-        {
-            "name": "localheinz/phpstan-rules",
-            "version": "0.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/phpstan-rules.git",
-                "reference": "e05ea16b61e48436a9ebb98e432de56b2dcf2034"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/e05ea16b61e48436a9ebb98e432de56b2dcf2034",
-                "reference": "e05ea16b61e48436a9ebb98e432de56b2dcf2034",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.2.3",
-                "php": "^7.1",
-                "phpstan/phpstan": "~0.11.15"
-            },
-            "require-dev": {
-                "infection/infection": "~0.13.6",
-                "localheinz/composer-normalize": "^1.3.1",
-                "localheinz/php-cs-fixer-config": "~1.23.0",
-                "localheinz/test-util": "~0.7.0",
-                "phpstan/phpstan-deprecation-rules": "~0.11.2",
-                "phpstan/phpstan-strict-rules": "~0.11.1",
-                "phpunit/phpunit": "^7.5.16",
-                "psr/container": "^1.0.0",
-                "zendframework/zend-servicemanager": "^2.0.0"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "rules.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\PHPStan\\Rules\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides additional rules for phpstan/phpstan.",
-            "homepage": "https://github.com/localheinz/phpstan-rules",
-            "keywords": [
-                "PHPStan",
-                "phpstan-extreme-rules",
-                "phpstan-rules"
-            ],
-            "time": "2019-10-15T09:23:25+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/phpstan-rules` instead of `localheinz/phpstan-rules`