### PR TITLE
Fix: Remove dependabot configuration without effect

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,19 +10,6 @@ update_configs:
     default_reviewers:
       - "localheinz"
     directory: "/"
-    package_manager: "github_actions"
-    update_schedule: "daily"
-
-  - automerged_updates:
-      - match:
-          dependency_type: "development"
-    default_assignees:
-      - "localheinz"
-    default_labels:
-      - "dependency"
-    default_reviewers:
-      - "localheinz"
-    directory: "/"
     package_manager: "php:composer"
     update_schedule: "daily"
     version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] removes dependabot configuration directives without effect