### PR TITLE
Fix: Use tags to specify versions of actions to be used

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: none
           extensions: "mbstring"
@@ -36,7 +36,7 @@ jobs:
         run: composer validate --strict
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: php${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}
@@ -53,7 +53,7 @@ jobs:
         run: mkdir -p .build/php-cs-fixer
 
       - name: "Cache cache directory for friendsofphp/php-cs-fixer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: .build/php-cs-fixer
           key: php${{ matrix.php-version }}-php-cs-fixer-${{ hashFiles('**/composer.lock') }}
@@ -78,14 +78,14 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: none
           extensions: "mbstring"
           php-version: ${{ matrix.php-version }}
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: php${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}
@@ -113,14 +113,14 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: none
           extensions: "mbstring"
           php-version: ${{ matrix.php-version }}
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: ${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}
@@ -155,14 +155,14 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: none
           extensions: "mbstring"
           php-version: ${{ matrix.php-version }}
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
@@ -205,14 +205,14 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: pcov
           extensions: "mbstring"
           php-version: ${{ matrix.php-version }}
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: php${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}
@@ -245,14 +245,14 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@1.6.0
         with:
           coverage: pcov
           extensions: "mbstring"
           php-version: ${{ matrix.php-version }}
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
+        uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
           key: php${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
This PR

* [x] uses concrete versions of actions

💁‍♂ At the moment it is a bit unclear which version of an action is actually used, so using concrete version provides a bit more clarity. Also see https://github.community/t5/GitHub-Actions/Referencing-major-version-of-GitHub-action-only-fails-to/m-p/40562#M4280.