### PR TITLE
Enhancement: Use webfactory/composer-require-checker instead of localheinz/composer-require-checker-action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,7 +96,7 @@ jobs:
         run: composer install --no-interaction --no-progress --no-suggest
 
       - name: "Run maglnet/composer-require-checker"
-        uses: docker://localheinz/composer-require-checker-action:1.1.1
+        uses: docker://webfactory/composer-require-checker:2.0.0
 
   static-code-analysis:
     name: "Static Code Analysis"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fix
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker
-	docker run --interactive --rm --tty --workdir=/app --volume ${PWD}:/app localheinz/composer-require-checker-action:1.1.1
+	docker run --interactive --rm --tty --volume ${PWD}:/app webfactory/composer-require-checker:2.0.0
 
 .PHONY: help
 help: ## Displays this list of targets with descriptions


### PR DESCRIPTION
This PR

* [x] uses  `webfactory/composer-require-checker` instead of `localheinz/composer-require-checker-action`

Follows #152.