### PR TITLE
Enhancement: Allow dependabot to automatically merge pull requests

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,10 @@
 version: 1
 
 update_configs:
-  - default_assignees:
+  - automerged_updates:
+      - match:
+          dependency_type: "development"
+    default_assignees:
       - "localheinz"
     default_labels:
       - "dependency"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -27,7 +27,9 @@ branches:
           - "codecov/patch"
           - "codecov/project"
         strict: false
-      restrictions: null
+      restrictions:
+        apps:
+          - slug: "dependabot-preview"
 
 labels:
   - name: bug


### PR DESCRIPTION
This PR

* [x] allows dependabot to automatically merge updates to development dependencies

Follows #192.

Also see https://github.com/dependabot/feedback/issues/86.