### PR TITLE
Fix: Include hashes when specifying color codes

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -42,22 +42,22 @@ branches:
 
 labels:
   - name: "bug"
-    color: "ee0701"
+    color: "#ee0701"
 
   - name: "dependency"
-    color: "0366d6"
+    color: "#0366d6"
 
   - name: "enhancement"
-    color: "0e8a16"
+    color: "#0e8a16"
 
   - name: "question"
-    color: "cc317c"
+    color: "#cc317c"
 
   - name: "security"
-    color: "ee0701"
+    color: "#ee0701"
 
   - name: "stale"
-    color: "eeeeee"
+    color: "#eeeeee"
 
 # https://developer.github.com/v3/repos/#edit
 


### PR DESCRIPTION
This PR

* [x] includes hashes when specifying color codes