### PR TITLE
Fix: Do not bother checking iterable type

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
+	checkMissingIterableValueType: false
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:


### PR DESCRIPTION
This PR

* [x] stops bothering with specifying iterable value types