### PR TITLE
Fix: Do not run builds for tags

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "master"
-    tags:
-      - "**"
 
 name: "Continuous Integration"
 


### PR DESCRIPTION
This PR

* [x] stops running builds for tags

💁‍♂ Not needed at this point!