### PR TITLE
Fix: Use caret operator for ergebnis/php-cs-fixer-config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.2.0",
-    "ergebnis/php-cs-fixer-config": "~1.1.3",
+    "ergebnis/php-cs-fixer-config": "^1.1.3",
     "ergebnis/phpstan-rules": "~0.14.2",
     "ergebnis/test-util": "~0.9.1",
     "infection/infection": "~0.15.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93f60615df109ecd3c646325177e3893",
+    "content-hash": "047dad00bd3271f2bb13bd53f5ceacfe",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] uses the `^` operator for requiring `ergebnis/php-cs-fixer-config`
