### PR TITLE
Fix: Use AUTO_APPROVE_TOKEN

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @localheinz

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -348,4 +348,4 @@ jobs:
         uses: "hmarr/auto-approve-action@v2.0.0"
         if: "(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'Build(deps-dev)')"
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.AUTO_APPROVE_TOKEN }}"


### PR DESCRIPTION
This PR

* [x] uses the `AUTO_APPROVE_TOKEN` again

🤷‍♂