### PR TITLE
Fix: Hide info level error messages emitted by vimeo/psalm

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -175,7 +175,7 @@ jobs:
         run: "mkdir -p .build/psalm"
 
       - name: "Run vimeo/psalm"
-        run: "vendor/bin/psalm --config=psalm.xml"
+        run: "vendor/bin/psalm --config=psalm.xml --show-info=false"
 
   tests:
     name: "Tests"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 	mkdir -p .build/phpstan
 	vendor/bin/phpstan analyse --configuration=phpstan.neon
 	mkdir -p .build/psalm
-	vendor/bin/psalm --config=psalm.xml
+	vendor/bin/psalm --config=psalm.xml --show-info=false
 
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm


### PR DESCRIPTION
This PR

* [x] hides info level error messages emitted by psalm