### PR TITLE
Fix: Remove default_assignes and default_reviewers configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,14 +9,8 @@ update_configs:
     commit_message:
       include_scope: true
       prefix: "Build"
-    default_assignees:
-      - "ergebnis-bot"
-      - "localheinz"
     default_labels:
       - "dependency"
-    default_reviewers:
-      - "ergebnis-bot"
-      - "localheinz"
     directory: "/"
     package_manager: "php:composer"
     update_schedule: "live"


### PR DESCRIPTION
This PR

* [x] removes the `default_assignees` and `default_reviewers` configuration

💁‍♂ This only duplicates the [`CODEOWNERS`](https://github.com/ergebnis/php-library-template/blob/f1da331dc34b9edfc85c006c335812ef7872aa95/.github/CODEOWNERS) facilities, as far as I'm concerned.