### PR TITLE
Fix: Add note about restrictions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -32,6 +32,12 @@ branches:
           - "codecov/project"
         strict: false
       restrictions:
+
+        # https://developer.github.com/v3/repos/branches/#parameters-1
+
+        # Note: User, app, and team restrictions are only available for organization-owned repositories.
+        # Set to null to disable when using this configuration for a repository on a personal account.
+
         apps:
           - "dependabot-preview"
         teams: []


### PR DESCRIPTION
This PR

* [x] adds a note about restrictions (as they are only available on organization-wide accounts)