### PR TITLE
Fix: Remove Patreon from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
 custom: "https://www.buymeacoffee.com/localheinz"
 github: "localheinz"
-patreon: "localheinz"


### PR DESCRIPTION
This PR

* [x] removes Patreon from `FUNDING.yml`