### PR TITLE
Fix: Do not require Approve job to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,7 +28,6 @@ branches:
           - "Tests (7.4, highest)"
           - "Code Coverage (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
-          - "Approve"
           - "codecov/patch"
           - "codecov/project"
         strict: false


### PR DESCRIPTION
This PR

* [x] reverts #270