### PR TITLE
Fix: Require Review job to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,6 +28,7 @@ branches:
           - "Tests (7.4, highest)"
           - "Code Coverage (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
+          - "Review"
           - "codecov/patch"
           - "codecov/project"
         strict: false


### PR DESCRIPTION
This PR

* [x] requires the Review job to pass

Follows #270.
Follows #271. 

💁‍♂ Yes, it's named Review, not Approve.