### PR TITLE
Fix: Wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ Please have a look at [`CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md).
 
 ## License
 
-This package is licensed using the [MIT License](LICENSE.md).
+This package is licensed using the MIT License.
+
+Please have a look at [`LICENSE.md`](LICENSE.md).


### PR DESCRIPTION
This PR

* [x] fixes the wording in `README.md` when referring to `LICENSE.md`