### PR TITLE
Fix: Remove mutation score badge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -329,8 +329,6 @@ jobs:
 
       - name: "Run mutation tests with pcov and infection/infection"
         run: "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${{ env.MIN_COVERED_MSI }} --min-msi=${{ env.MIN_MSI }}"
-        env:
-          STRYKER_DASHBOARD_API_KEY: "${{ secrets.STRYKER_DASHBOARD_API_KEY }}"
 
   review:
     name: "Review"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![Continuous Deployment](https://github.com/ergebnis/php-library-template/workflows/Continuous%20Deployment/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
 [![Continuous Integration](https://github.com/ergebnis/php-library-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
 
-[![Type Coverage](https://shepherd.dev/github/ergebnis/php-library-template/coverage.svg)](https://shepherd.dev/github/ergebnis/php-library-template)
 [![Code Coverage](https://codecov.io/gh/ergebnis/php-library-template/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-library-template)
-[![Mutation Score](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fergebnis%2Fphp-library-template%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/ergebnis/php-library-template/master)
+[![Type Coverage](https://shepherd.dev/github/ergebnis/php-library-template/coverage.svg)](https://shepherd.dev/github/ergebnis/php-library-template)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/php-library-template/v/stable)](https://packagist.org/packages/ergebnis/php-library-template)
 [![Total Downloads](https://poser.pugx.org/ergebnis/php-library-template/downloads)](https://packagist.org/packages/ergebnis/php-library-template)

--- a/infection.json
+++ b/infection.json
@@ -9,9 +9,6 @@
     "configDir": "test\/Unit"
   },
   "logs": {
-    "badge": {
-      "branch": "master"
-    },
     "text": ".build/infection/infection-log.txt"
   }
 }


### PR DESCRIPTION
This PR

* [x] removes the mutation score badge

Follows #291.

💁‍♂ Missing support for platforms other than Travis CI (see https://github.com/infection/infection/pull/939).