### PR TITLE
Remove leading `#` of color labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -49,27 +49,27 @@ branches:
 
 labels:
   - name: "bug"
-    color: "#ee0701"
+    color: "ee0701"
     description: ""
 
   - name: "dependency"
-    color: "#0366d6"
+    color: "0366d6"
     description: ""
 
   - name: "enhancement"
-    color: "#0e8a16"
+    color: "0e8a16"
     description: ""
 
   - name: "question"
-    color: "#cc317c"
+    color: "cc317c"
     description: ""
 
   - name: "security"
-    color: "#ee0701"
+    color: "ee0701"
     description: ""
 
   - name: "stale"
-    color: "#eeeeee"
+    color: "eeeeee"
     description: ""
 
 # https://developer.github.com/v3/repos/#edit


### PR DESCRIPTION
This PR

* [x] Remove leading `#` of color labels

Reverts #210.

https://developer.github.com/v3/issues/labels/#create-a-label clearly states that it doesn't supports it.
