### PR TITLE
Enhancement: Cache cache directory for phpstan/phpstan

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,6 +180,13 @@ jobs:
       - name: "Create cache directory for phpstan/phpstan"
         run: "mkdir -p .build/phpstan"
 
+      - name: "Cache cache directory for phpstan/phpstan"
+        uses: "actions/cache@v1"
+        with:
+          path: ".build/phpstan"
+          key: "php-${{ matrix.php-version }}-phpstan-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-phpstan-"
+
       - name: "Run phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan.neon"
 


### PR DESCRIPTION
This PR

* [x] caches the cache directory for `phpstan/phpstan` between builds

💁‍♂ For reference, see https://medium.com/@ondrejmirtes/from-minutes-to-seconds-massive-performance-gains-in-phpstan-163be88d1519.