### PR TITLE
Fix: Do not cache cache directory for phpstan/phpstan

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -180,13 +180,6 @@ jobs:
       - name: "Create cache directory for phpstan/phpstan"
         run: "mkdir -p .build/phpstan"
 
-      - name: "Cache cache directory for phpstan/phpstan"
-        uses: "actions/cache@v1"
-        with:
-          path: ".build/phpstan"
-          key: "php-${{ matrix.php-version }}-phpstan-${{ hashFiles('**/composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-phpstan-"
-
       - name: "Run phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan.neon"
 


### PR DESCRIPTION
This PR

* [x] reverts #327 

💁‍♂ In a different project we ran into some issues - static code analysis failed, likely due to caching issues. These issues might have been resolved in the meanwhile, but better safe than sorry.
