### PR TITLE
Fix: Renew workflow should run on PHP 7.2

### DIFF
--- a/.github/workflows/renew.yml
+++ b/.github/workflows/renew.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"


### PR DESCRIPTION
This PR

* [x] runs the _Renew_ workflow on PHP 7.2

Spotted in #334.