### PR TITLE
Fix: Create directory for phpunit cache result file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ it: coding-standards dependency-analysis static-code-analysis tests ## Runs the 
 
 .PHONY: code-coverage
 code-coverage: vendor ## Collects coverage from running unit tests with phpunit/phpunit
+	mkdir -p .build/phpunit
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-text
 
 .PHONY: coding-standards


### PR DESCRIPTION
This PR

* [x] creates the directory used for `phpunit` result cache files in the `code-coverage` target
