### PR TITLE
Fix: support yml and yaml extension file in editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ indent_size = 2
 [*.neon]
 indent_style = tab
 
-[*.yaml]
+[*.{yaml,yml}]
 indent_size = 2
 
 [Makefile]


### PR DESCRIPTION
This PR

* [x] support yml and yaml extension file in editor config

Follows #338 

We still have `.github/settings.yml`.