### PR TITLE
Enhancement: Cache cache directory for phpstan/phpstan

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -187,6 +187,13 @@ jobs:
       - name: "Create cache directory for phpstan/phpstan"
         run: "mkdir -p .build/phpstan"
 
+      - name: "Cache cache directory for phpstan/phpstan"
+        uses: "actions/cache@v1"
+        with:
+          path: ".build/phpstan"
+          key: "php-${{ matrix.php-version }}-phpstan-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-phpstan-"
+
       - name: "Run phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan.neon"
 


### PR DESCRIPTION
This PR

* [x] caches the cache directory for `phpstan/phpstan`

Blocked by #349.
Follows #328.
Follows #327.