### PR TITLE
Fix: Do not check multi-line strings for indentation

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -32,7 +32,7 @@ rules:
   document-start:
     present: false
   indentation:
-    check-multi-line-strings: true
+    check-multi-line-strings: false
     indent-sequences: true
     spaces: 2
   empty-lines:


### PR DESCRIPTION
This PR

* [x] disables indentation checking for multi-line strings

Follows #339.