### PR TITLE
Fix: Remove dependabot from restriction exclusions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,8 +38,7 @@ branches:
         # Note: User, app, and team restrictions are only available for organization-owned repositories.
         # Set to null to disable when using this configuration for a repository on a personal account.
 
-        apps:
-          - "dependabot-preview"
+        apps: []
         teams: []
         users:
           - "ergebnis-bot"


### PR DESCRIPTION
This PR

* [x] removes Dependabot from restrictions

Follows #363.