### PR TITLE
Fix: Exclude dependency-analysis from it target

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Run
 $ make
 ```
 
-to enforce coding standards, run a dependency analysis, run a static code analysis, and run tests!
+to enforce coding standards, run a static code analysis, and run tests!
 
 ## Help
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MIN_COVERED_MSI:=100
 MIN_MSI:=100
 
 .PHONY: it
-it: coding-standards dependency-analysis static-code-analysis tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, and tests targets
+it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets
 
 .PHONY: code-coverage
 code-coverage: vendor ## Collects coverage from running unit tests with phpunit/phpunit


### PR DESCRIPTION
This PR

* [x] excludes `dependency-analysis` from the `it` target

💁‍♂ It's slow, and that's annoying. 