### PR TITLE
Fix: Ignore .notes directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.build/
+/.notes/
 /vendor/

--- a/.php_cs
+++ b/.php_cs
@@ -35,6 +35,7 @@ $config->getFinder()
         '.build/',
         '.dependabot/',
         '.github/',
+        '.notes/',
     ])
     ->name('.php_cs');
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,6 +2,7 @@ extends: "default"
 
 ignore: |
   .build/
+  .notes/
   vendor/
 
 rules:


### PR DESCRIPTION
This PR

* [x] ignores the `.notes` directory

Related to https://localheinz.com/blog/2019/10/25/project-notes/.