### PR TITLE
Fix: Remove placeholder

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,4 +8,4 @@ parameters:
 	paths:
 		- src/
 		- test/
-	tmpDir: %currentWorkingDirectory%/.build/phpstan/
+	tmpDir: .build/phpstan/


### PR DESCRIPTION
This PR

* [x] removes an unnecessary placeholder from `phpstan.neon`