### PR TITLE
Fix: Add note about yamllint to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,17 @@ For details, take a look at the following workflow configuration files:
 
 ## Coding Standards
 
-We are using [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce coding standards.
+We are using [`yamllint`](https://github.com/adrienverge/yamllint) to enforce coding standards in YAML files.
+
+If you do not have `yamllint` installed yet, run
+
+```
+$ brew install yamllint
+```
+
+to install `yamllint`.
+
+We are using [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce coding standards in PHP files.
 
 Run
 


### PR DESCRIPTION
This PR

* [x] adds a note about `yamllint` to `CONTRIBUTING.md`