### PR TITLE
Fix: Consistently quote strings in YAML files

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -62,5 +62,5 @@ rules:
       - "true"
 
 yaml-files:
-  - '*.yaml'
-  - '*.yml'
+  - "*.yaml"
+  - "*.yml"


### PR DESCRIPTION
This PR

* [x] consistently quotes strings in YAML files