### PR TITLE
Enhancement: Add label based on branch name

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,42 @@
+name: "Triage"
+
+on: # yamllint disable-line rule:truthy
+  pull_request: null
+
+jobs:
+  label:
+    name: "Label"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Add labels based on branch name"
+        if: "github.event.action == 'opened'"
+        uses: "actions/github-script@0.8.0"
+        with:
+          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+          script: |
+            const branchPrefixLabels = {
+              enhancement: "feature",
+              fix: "bug",
+            }
+
+            const pullRequest = context.payload.pull_request
+            const repository = context.repo
+
+            const branchName = pullRequest.head.ref
+
+            const matches = branchName.match(new RegExp('^([^/]+)\/'));
+
+            if (matches instanceof Array && branchPrefixLabels.hasOwnProperty(matches[1])) {
+              const label = branchPrefixLabels[matches[1]]
+
+              github.issues.addLabels({
+                issue_number: pullRequest.number,
+                labels: [
+                  label
+                ],
+                owner: repository.owner,
+                repo: repository.repo,
+              });
+            }


### PR DESCRIPTION
This PR

* [x] adds a `Triage` workflow with a job containing a step that adds pull request labels based on the branch name