### PR TITLE
Fix: Map

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -17,7 +17,7 @@ jobs:
           github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
           script: |
             const branchPrefixLabels = {
-              enhancement: "feature",
+              feature: "enhancement",
               fix: "bug",
             }
 


### PR DESCRIPTION
This PR

* [x] fixes a map of branch name prefixes to labels

Follows #395.