### PR TITLE
Fix: Require label job to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,6 +28,7 @@ branches:
           - "Tests (7.4, highest)"
           - "Code Coverage (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
+          - "Label"
         strict: false
       restrictions:
 


### PR DESCRIPTION
This PR

* [x] requires the `label` job to pass

