### PR TITLE
Fix: Keep required jobs sorted by name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,21 +14,21 @@ branches:
         required_approving_review_count: 1
       required_status_checks:
         contexts:
+          - "Code Coverage (7.4, locked)"
           - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
-          - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.2, lowest)"
-          - "Tests (7.2, locked)"
-          - "Tests (7.2, highest)"
-          - "Tests (7.3, lowest)"
-          - "Tests (7.3, locked)"
-          - "Tests (7.3, highest)"
-          - "Tests (7.4, lowest)"
-          - "Tests (7.4, locked)"
-          - "Tests (7.4, highest)"
-          - "Code Coverage (7.4, locked)"
-          - "Mutation Tests (7.4, locked)"
           - "Label"
+          - "Mutation Tests (7.4, locked)"
+          - "Static Code Analysis (7.4, locked)"
+          - "Tests (7.2, highest)"
+          - "Tests (7.2, locked)"
+          - "Tests (7.2, lowest)"
+          - "Tests (7.3, highest)"
+          - "Tests (7.3, locked)"
+          - "Tests (7.3, lowest)"
+          - "Tests (7.4, highest)"
+          - "Tests (7.4, locked)"
+          - "Tests (7.4, lowest)"
         strict: false
       restrictions:
 


### PR DESCRIPTION
This PR

* [x] keeps required jobs sorted by name
