### PR TITLE
Fix: Use caret operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ergebnis/license": "^1.0.0",
     "ergebnis/php-cs-fixer-config": "^2.1.2",
     "ergebnis/phpstan-rules": "~0.14.4",
-    "ergebnis/test-util": "~1.0.0",
+    "ergebnis/test-util": "^1.0.0",
     "infection/infection": "~0.15.3",
     "jangregor/phpstan-prophecy": "~0.6.2",
     "phpstan/extension-installer": "^1.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d33e9092e86651672a364f1b9e235d4",
+    "content-hash": "b733e1bec6ffc951a7626b702a1c414d",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] uses the `^` operator for requiring `ergebnis/test-util`