### PR TITLE
Fix: Import parent namespace only

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,7 +12,7 @@ declare(strict_types=1);
  */
 
 use Ergebnis\License;
-use Ergebnis\PhpCsFixer\Config;
+use Ergebnis\PhpCsFixer;
 
 $license = License\Type\MIT::markdown(
     __DIR__ . '/LICENSE.md',
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php71($license->header()));
 
 $config->getFinder()
     ->ignoreDotFiles(false)

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Library\Test\Unit;
 
 use Ergebnis\Library\Example;
-use Ergebnis\Test\Util\Helper;
+use Ergebnis\Test\Util;
 use PHPUnit\Framework;
 
 /**
@@ -24,7 +24,7 @@ use PHPUnit\Framework;
  */
 final class ExampleTest extends Framework\TestCase
 {
-    use Helper;
+    use Util\Helper;
 
     public function testFromNameReturnsExample(): void
     {


### PR DESCRIPTION
This PR

* [x] imports parent namespaces only