### PR TITLE
Enhancement: Use event types instead of custom if

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,7 +1,9 @@
 name: "Triage"
 
 on: # yamllint disable-line rule:truthy
-  pull_request: null
+  pull_request:
+    types:
+      - "opened"
 
 jobs:
   label:
@@ -11,7 +13,6 @@ jobs:
 
     steps:
       - name: "Add labels based on branch name"
-        if: "github.event.action == 'opened'"
         uses: "actions/github-script@v1"
         with:
           github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"


### PR DESCRIPTION
This PR

* [x] Use event types instead of custom if

For reference, see https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onevent_nametypes and https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request.