### PR TITLE
Fix: Remove reference to previously removed directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/.dependabot/           export-ignore
 /.github/               export-ignore
 /test/                  export-ignore
 /tools/                 export-ignore

--- a/.php_cs
+++ b/.php_cs
@@ -33,7 +33,6 @@ $config->getFinder()
     ->in(__DIR__)
     ->exclude([
         '.build/',
-        '.dependabot/',
         '.github/',
         '.notes/',
     ])


### PR DESCRIPTION
This PR

* [x] removes a reference to a previously removed directory

Follows #445.