### PR TITLE
Fix: Do not require Label job to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -17,7 +17,6 @@ branches:
           - "Code Coverage (7.4, locked)"
           - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
-          - "Label"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
           - "Tests (7.2, highest)"


### PR DESCRIPTION
This PR

* [x] stops requiring the Label job to pass

💁‍♂️ It only runs when a pull request is opened, but not when it is pushed into.

