### PR TITLE
Enhancement: Configure psalm to enforce strict typing on numerical and string operations

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     errorLevel="1"
     findUnusedVariablesAndParams="true"
     resolveFromConfigFile="true"
+    strictBinaryOperands="true"
 >
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />


### PR DESCRIPTION
This PR

* [x] configures `vimeo/psalm` to enforce strict typing on numerical and string operations

💁‍♂️ For reference, see https://psalm.dev/docs/running_psalm/configuration/.