### PR TITLE
Enhancement: Run triage workflow on pull_request_target event

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -3,7 +3,7 @@
 name: "Triage"
 
 on: # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
 


### PR DESCRIPTION
This PR

* [x] runs the triage workflow on the `pull_request_target` event

💁‍♂️ For reference, see https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.