### PR TITLE
Fix: Exit with exit code from running composer

### DIFF
--- a/.github/actions/composer/composer/install/run.sh
+++ b/.github/actions/composer/composer/install/run.sh
@@ -5,19 +5,19 @@ dependencies="${COMPOSER_INSTALL_DEPENDENCIES}"
 if [[ ${dependencies} == "lowest" ]]; then
   composer update --no-interaction --no-progress --no-suggest --prefer-lowest
 
-  exit 0
+  exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
   composer install --no-interaction --no-progress --no-suggest
 
-  exit 0
+  exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
   composer update --no-interaction --no-progress --no-suggest
 
-  exit 0
+  exit $?
 fi
 
 echo "::error::The value for the \"dependencies\" input needs to be one of \"lowest\", \"locked\"', \"highest\"' - got \"${dependencies}\" instead."


### PR DESCRIPTION
This PR

* [x] exits with the exit code from running `composer`

💁‍♂️ Otherwise steps succeed when they should have failed.