### PR TITLE
Correct the cache key for php-cs-fixer

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: "actions/cache@v2.1.1"
         with:
           path: ".build/php-cs-fixer"
-          key: "php-${{ matrix.php-version }}-php-cs-fixer-${{ hashFiles('composer.lock') }}"
+          key: "php-${{ matrix.php-version }}-php-cs-fixer-${{ github.sha }}"
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: "actions/cache@v2.1.1"
         with:
           path: ".build/php-cs-fixer"
-          key: "php-${{ matrix.php-version }}-php-cs-fixer-${{ hashFiles('composer.lock') }}"
+          key: "php-${{ matrix.php-version }}-php-cs-fixer-${{ github.sha }}"
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"


### PR DESCRIPTION
The cache key for php-cs-fixer needs to be changing with the source code, so the cache is updated.

This is the same method used in the static analysis tools.