### PR TITLE
Fix: Echo COMPOSER_CACHE_DIR environment variable into $GITHUB_ENV instead of using set-env

### DIFF
--- a/.github/actions/composer/composer/determine-cache-directory/action.yaml
+++ b/.github/actions/composer/composer/determine-cache-directory/action.yaml
@@ -13,4 +13,4 @@ runs:
   steps:
     - name: "Determine composer cache directory"
       shell: "bash"
-      run: "echo \"::set-env name=COMPOSER_CACHE_DIR::$(composer config cache-dir)\""
+      run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"


### PR DESCRIPTION
This PR

* [x] echos the `COMPOSER_CACHE_DIR` environment variable into `$GITHUB_ENV` instead of using `set-env`

💁‍♂️ For reference, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.