### PR TITLE
Fix: Order

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -29,13 +29,13 @@ $license->save();
 $config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php71($license->header()));
 
 $config->getFinder()
-    ->ignoreDotFiles(false)
-    ->in(__DIR__)
     ->exclude([
         '.build/',
         '.github/',
         '.notes/',
     ])
+    ->ignoreDotFiles(false)
+    ->in(__DIR__)
     ->name('.php_cs');
 
 $config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');


### PR DESCRIPTION
This PR

* [x] fixes the order of method calls

💁‍♂️ The order does not matter, so we can just as well use alphabetical order.