### PR TITLE
Fix: Use major.minor.patch version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: "actions/checkout@v2.3.3"
 
       - name: "Lint YAML files"
-        uses: "ibiqlik/action-yamllint@v2"
+        uses: "ibiqlik/action-yamllint@v2.0.0"
         with:
           config_file: ".yamllint.yaml"
           file_or_dir: "."


### PR DESCRIPTION
This PR

* [x] uses `major.minor.patch` version

Follows #577.