### PR TITLE
Fix: Remove deprecated --no-suggest option

### DIFF
--- a/.github/actions/composer/composer/install/run.sh
+++ b/.github/actions/composer/composer/install/run.sh
@@ -3,19 +3,19 @@
 dependencies="${COMPOSER_INSTALL_DEPENDENCIES}"
 
 if [[ ${dependencies} == "lowest" ]]; then
-  composer update --no-interaction --no-progress --no-suggest --prefer-lowest
+  composer update --no-interaction --no-progress --prefer-lowest
 
   exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
-  composer install --no-interaction --no-progress --no-suggest
+  composer install --no-interaction --no-progress
 
   exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
-  composer update --no-interaction --no-progress --no-suggest
+  composer update --no-interaction --no-progress
 
   exit $?
 fi

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ tests: vendor ## Runs auto-review, unit, and integration tests with phpunit/phpu
 
 vendor: composer.json composer.lock
 	composer validate --strict
-	composer install --no-interaction --no-progress --no-suggest
+	composer install --no-interaction --no-progress


### PR DESCRIPTION
This PR

* [x] removes the deprecated `--no-suggest` option when installing or updating dependencies with `composer`