### PR TITLE
Fix: Remove localheinz from condition for merge job

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -357,8 +357,7 @@ jobs:
       ) && (
         (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'composer(deps-dev)')) ||
         (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'github-actions(deps)')) ||
-        (github.actor == 'ergebnis-bot' && github.event.pull_request.title == 'Enhancement: Update license year') ||
-        (github.actor == 'localheinz' && contains(github.event.pull_request.labels.*.name, 'merge'))
+        (github.actor == 'ergebnis-bot' && github.event.pull_request.title == 'Enhancement: Update license year')
       )
 
     steps:


### PR DESCRIPTION
This PR

* [x] removes @localheinz from the condition for the merge job