### PR TITLE
Fix: Reduce dependabot pull request limit from 10 to 1

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     labels:
       - "dependency"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: "composer"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR

* [x] reduces the dependabot pull request limit from 10 to 1 for `composer`

💁‍♂️ For reference, see https://twitter.com/localheinz/status/1337825636396756992.