### PR TITLE
Fix: Let dependabot update once a day

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 1
     package-ecosystem: "composer"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     versioning-strategy: "increase"
 
   - commit-message:
@@ -24,4 +24,4 @@ updates:
     open-pull-requests-limit: 10
     package-ecosystem: "github-actions"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
This PR

* [x] lets dependabot update once a day

Reverts #603.
Follows #604.

💁‍♂️ With #604 in place, I'm afraid it will be impossible to keep up-to-date in repositories depending on, for example, a range of `symfony/*` components.