### PR TITLE
Enhancement: Run dependency analysis on PHP 8.0

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,7 +16,7 @@ branches:
         contexts:
           - "Code Coverage (8.0, locked)"
           - "Coding Standards (7.2, locked)"
-          - "Dependency Analysis (7.4, locked)"
+          - "Dependency Analysis (8.0, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
           - "Tests (7.2, highest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
         dependencies:
           - "locked"


### PR DESCRIPTION
This PR

* [x] runs the dependency analysis on PHP 8.0

❗ Blocked by https://github.com/maglnet/ComposerRequireChecker/pull/201.