### PR TITLE
Enhancement: Run mutation tests on PHP 8.0

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -17,7 +17,7 @@ branches:
           - "Code Coverage (8.0, locked)"
           - "Coding Standards (7.3, locked)"
           - "Dependency Analysis (7.4, locked)"
-          - "Mutation Tests (7.4, locked)"
+          - "Mutation Tests (8.0, locked)"
           - "Static Code Analysis (8.0, locked)"
           - "Tests (7.3, highest)"
           - "Tests (7.3, locked)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -300,7 +300,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
         dependencies:
           - "locked"


### PR DESCRIPTION
This PR

* [x] runs mutation tests on PHP 8.0

❗ Blocked by https://github.com/ergebnis/php-library-template/pull/621.