### PR TITLE
Fix: Drop support for PHP 7.2

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (8.0, locked)"
-          - "Coding Standards (7.2, locked)"
+          - "Coding Standards (7.3, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (8.0, locked)"
-          - "Tests (7.2, highest)"
-          - "Tests (7.2, locked)"
-          - "Tests (7.2, lowest)"
           - "Tests (7.3, highest)"
           - "Tests (7.3, locked)"
           - "Tests (7.3, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.3"
 
         dependencies:
           - "locked"
@@ -195,7 +195,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.3"
 
         dependencies:
           - "locked"

--- a/.php_cs
+++ b/.php_cs
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php71($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php73($license->header()));
 
 $config->getFinder()
     ->exclude([

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.2.25"
+      "php": "7.3.24"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90fee0a035455c62cdd25f99bf29e040",
+    "content-hash": "55f2f44f01fc2ba6ba1e32c7b9861cc1",
     "packages": [],
     "packages-dev": [
         {
@@ -6006,7 +6006,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.25"
+        "php": "7.3.24"
     },
     "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.2

💁‍♂️ Official support for PHP 7.2 ended on November 30, 2020. For reference, see 

- https://www.php.net/supported-versions.php
- https://www.php.net/eol.php

![EqMGRuZXUAAey8Y](https://user-images.githubusercontent.com/605483/103158497-cdf9f180-47be-11eb-9999-5492a00be280.jpeg)
