### PR TITLE
Fix: Raise limit from 1 to 10

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     labels:
       - "dependency"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 10
     package-ecosystem: "composer"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This PR

* [x] raises the limit for the number of pull requests Dependabot can open at the same time from 1 to 10

🤷‍♂️ 