### PR TITLE
Fix: Do not run with --dry-run option

### DIFF
--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose"
 
       - name: "Open pull request updating license year"
         uses: "gr2m/create-or-update-pull-request-action@v1.3.3"


### PR DESCRIPTION
This PR

* [x] stops using the `--dry-run` option in the _Renew_ workflow