### PR TITLE
Fix: Avoid acronym

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-This PR
+This pull request
 
 * [x]
 


### PR DESCRIPTION
This PR

* [x] avoids an unnecessary acronym