### PR TITLE
Fix: Use Xdebug instead of pcov for collecting code coverage

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -259,7 +259,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@2.9.0"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -281,7 +281,7 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Collect code coverage with pcov and phpunit/phpunit"
+      - name: "Collect code coverage with Xdebug and phpunit/phpunit"
         run: "vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to Codecov.io"
@@ -309,7 +309,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@2.9.0"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -328,7 +328,7 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Run mutation tests with pcov and infection/infection"
+      - name: "Run mutation tests with Xdebug and infection/infection"
         run: "vendor/bin/infection --configuration=infection.json"
 
   merge:


### PR DESCRIPTION
This pull request

* [x] uses `Xdebug` instead of `pcov` for collecting code coverage

💁‍♂️ It's more precise, and not as slow anymore.