### PR TITLE
Fix: ignore composer.lock file when exporting the sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.gitignore                     export-ignore
 /.php_cs                        export-ignore
 /composer-require-checker.json  export-ignore
+/composer.lock                  export-ignore
 /infection.json                 export-ignore
 /Makefile                       export-ignore
 /phpstan-baseline.neon          export-ignore


### PR DESCRIPTION
It's pointless to include it in the source archives, it's there only to have a reproducible dev environment.