### PR TITLE
Fix: Rename repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -88,7 +88,7 @@ repository:
   has_pages: false
   has_projects: false
   has_wiki: false
-  name: "php-library-template"
+  name: "php-package-template"
   private: false
 
   # https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/ergebnis/php-library-template
+ * @see https://github.com/ergebnis/php-package-template
  */
 
 use Ergebnis\License;
@@ -21,7 +21,7 @@ $license = License\Type\MIT::markdown(
         new \DateTimeZone('UTC'),
     ),
     License\Holder::fromString('Andreas Möller'),
-    License\Url::fromString('https://github.com/ergebnis/php-library-template'),
+    License\Url::fromString('https://github.com/ergebnis/php-package-template'),
 );
 
 $license->save();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1902cc2...main`][1902cc2...main].
 
-[1902cc2...main]: https://github.com/ergebnis/php-library-template/compare/1902cc2...main
+[1902cc2...main]: https://github.com/ergebnis/php-package-template/compare/1902cc2...main

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# php-library-template
+# php-package-template
 
-[![Integrate](https://github.com/ergebnis/php-library-template/workflows/Integrate/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
-[![Prune](https://github.com/ergebnis/php-library-template/workflows/Prune/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
-[![Release](https://github.com/ergebnis/php-library-template/workflows/Release/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
-[![Renew](https://github.com/ergebnis/php-library-template/workflows/Renew/badge.svg)](https://github.com/ergebnis/php-library-template/actions)
+[![Integrate](https://github.com/ergebnis/php-package-template/workflows/Integrate/badge.svg)](https://github.com/ergebnis/php-package-template/actions)
+[![Prune](https://github.com/ergebnis/php-package-template/workflows/Prune/badge.svg)](https://github.com/ergebnis/php-package-template/actions)
+[![Release](https://github.com/ergebnis/php-package-template/workflows/Release/badge.svg)](https://github.com/ergebnis/php-package-template/actions)
+[![Renew](https://github.com/ergebnis/php-package-template/workflows/Renew/badge.svg)](https://github.com/ergebnis/php-package-template/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/php-library-template/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-library-template)
-[![Type Coverage](https://shepherd.dev/github/ergebnis/php-library-template/coverage.svg)](https://shepherd.dev/github/ergebnis/php-library-template)
+[![Code Coverage](https://codecov.io/gh/ergebnis/php-package-template/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-package-template)
+[![Type Coverage](https://shepherd.dev/github/ergebnis/php-package-template/coverage.svg)](https://shepherd.dev/github/ergebnis/php-package-template)
 
-[![Latest Stable Version](https://poser.pugx.org/ergebnis/php-library-template/v/stable)](https://packagist.org/packages/ergebnis/php-library-template)
-[![Total Downloads](https://poser.pugx.org/ergebnis/php-library-template/downloads)](https://packagist.org/packages/ergebnis/php-library-template)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/php-package-template/v/stable)](https://packagist.org/packages/ergebnis/php-package-template)
+[![Total Downloads](https://poser.pugx.org/ergebnis/php-package-template/downloads)](https://packagist.org/packages/ergebnis/php-package-template)
 
 ## Installation
 
@@ -18,7 +18,7 @@
 Run
 
 ```sh
-$ composer require ergebnis/php-library-template
+$ composer require ergebnis/php-package-template
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "ergebnis/php-library-template",
+  "name": "ergebnis/php-package-template",
   "type": "library",
   "description": "Provides a GitHub repository template for a PHP library, using GitHub actions.",
-  "homepage": "https://github.com/ergebnis/php-library-template",
+  "homepage": "https://github.com/ergebnis/php-package-template",
   "license": "MIT",
   "authors": [
     {
@@ -44,16 +44,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Ergebnis\\Library\\": "src/"
+      "Ergebnis\\Package\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Ergebnis\\Library\\Test\\": "test/"
+      "Ergebnis\\Package\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/ergebnis/php-library-template/issues",
-    "source": "https://github.com/ergebnis/php-library-template"
+    "issues": "https://github.com/ergebnis/php-package-template/issues",
+    "source": "https://github.com/ergebnis/php-package-template"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "982a01fa6a34868986587297e49094d6",
+    "content-hash": "e67236dd5d23ebf3c12005dfd3d67843",
     "packages": [],
     "packages-dev": [
         {
@@ -172,79 +172,6 @@
                 }
             ],
             "time": "2021-03-30T17:13:30+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-24T07:46:03+00:00"
         },
         {
             "name": "composer/semver",
@@ -2057,6 +1984,68 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.5"
             },
             "time": "2021-05-03T19:11:20+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "a7e35c34bc166a5684a1e2f13da7b1d6a821349d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a7e35c34bc166a5684a1e2f13da7b1d6a821349d",
+                "reference": "a7e35c34bc166a5684a1e2f13da7b1d6a821349d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0.0",
+                "php": "^7.4.7 || ~8.0.0"
+            },
+            "replace": {
+                "composer/package-versions-deprecated": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0.0@dev",
+                "doctrine/coding-standard": "^8.1.0",
+                "ext-zip": "^1.15.0",
+                "infection/infection": "dev-master#8d6c4d6b15ec58d3190a78b7774a5d604ec1075a",
+                "phpunit/phpunit": "~9.3.11",
+                "vimeo/psalm": "^4.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/Ocramius/PackageVersions/issues",
+                "source": "https://github.com/Ocramius/PackageVersions/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-21T13:48:04+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -6444,5 +6433,5 @@
     "platform-overrides": {
         "php": "7.4.16"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Example.php
+++ b/src/Example.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/ergebnis/php-library-template
+ * @see https://github.com/ergebnis/php-package-template
  */
 
-namespace Ergebnis\Library;
+namespace Ergebnis\Package;
 
 final class Example
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/ergebnis/php-library-template
+ * @see https://github.com/ergebnis/php-package-template
  */
 
-namespace Ergebnis\Library\Test\AutoReview;
+namespace Ergebnis\Package\Test\AutoReview;
 
 use Ergebnis\Test\Util;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src/',
-            'Ergebnis\\Library\\',
-            'Ergebnis\\Library\\Test\\Unit\\',
+            'Ergebnis\\Package\\',
+            'Ergebnis\\Package\\Test\\Unit\\',
         );
     }
 }

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/ergebnis/php-library-template
+ * @see https://github.com/ergebnis/php-package-template
  */
 
-namespace Ergebnis\Library\Test\Unit;
+namespace Ergebnis\Package\Test\Unit;
 
-use Ergebnis\Library\Example;
+use Ergebnis\Package\Example;
 use Ergebnis\Test\Util;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\Library\Example
+ * @covers \Ergebnis\Package\Example
  */
 final class ExampleTest extends Framework\TestCase
 {


### PR DESCRIPTION
This pull request

* [x] renames the repository from `ergebnis/php-library-template` to `ergebnis/php-package-template`

💁‍♂️ I believe package is a more common term.